### PR TITLE
✨ Feature: 지출 수정 

### DIFF
--- a/src/main/java/jaringobi/common/response/ApiResponse.java
+++ b/src/main/java/jaringobi/common/response/ApiResponse.java
@@ -1,7 +1,10 @@
 package jaringobi.common.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.springframework.http.HttpStatus;
 
+@JsonInclude(Include.NON_NULL)
 public record ApiResponse<T>(int code, T data) {
 
     public static <T> ApiResponse<T> ok(T data) {

--- a/src/main/java/jaringobi/controller/ExpenseController.java
+++ b/src/main/java/jaringobi/controller/ExpenseController.java
@@ -8,11 +8,13 @@ import jaringobi.controller.request.ModifyExpenseRequest;
 import jaringobi.controller.response.AddExpenseNoResponse;
 import jaringobi.domain.user.AppUser;
 import jaringobi.service.ExpenseService;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -33,11 +35,13 @@ public class ExpenseController {
     }
 
     @PutMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public ApiResponse<Void> modifyExpense(
             @PathVariable Long id,
             @AuthenticationPrincipal AppUser appUser,
             @Valid @RequestBody ModifyExpenseRequest modifyExpenseRequest
     ) {
+
         expenseService.modifyExpense(modifyExpenseRequest, id, appUser);
         return ApiResponse.noContent();
     }

--- a/src/main/java/jaringobi/controller/ExpenseController.java
+++ b/src/main/java/jaringobi/controller/ExpenseController.java
@@ -4,10 +4,13 @@ import jakarta.validation.Valid;
 import jaringobi.auth.AuthenticationPrincipal;
 import jaringobi.common.response.ApiResponse;
 import jaringobi.controller.request.AddExpenseRequest;
+import jaringobi.controller.request.ModifyExpenseRequest;
 import jaringobi.controller.response.AddExpenseNoResponse;
 import jaringobi.domain.user.AppUser;
 import jaringobi.service.ExpenseService;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +30,16 @@ public class ExpenseController {
             @AuthenticationPrincipal AppUser appUser,
             @Valid @RequestBody AddExpenseRequest addExpenseRequest) {
         return ApiResponse.ok(expenseService.addExpense(addExpenseRequest, appUser));
+    }
+
+    @PutMapping("/{id}")
+    public ApiResponse<Void> modifyExpense(
+            @PathVariable Long id,
+            @AuthenticationPrincipal AppUser appUser,
+            @Valid @RequestBody ModifyExpenseRequest modifyExpenseRequest
+    ) {
+        expenseService.modifyExpense(modifyExpenseRequest, id, appUser);
+        return ApiResponse.noContent();
     }
 
 }

--- a/src/main/java/jaringobi/controller/request/ModifyExpenseRequest.java
+++ b/src/main/java/jaringobi/controller/request/ModifyExpenseRequest.java
@@ -1,0 +1,52 @@
+package jaringobi.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jaringobi.domain.budget.Money;
+import jaringobi.domain.category.Category;
+import jaringobi.domain.expense.Expense;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ModifyExpenseRequest {
+
+    @NotNull(message = "지출 금액은 필수입니다.")
+    @Positive(message = "지출 금액은 최소 0원 보다 커야합니다.")
+    private Integer expenseMount;
+
+    @NotNull(message = "지출일은 필수입니다.")
+    private LocalDateTime expenseDateTime;
+
+    @NotNull(message = "카테고리는 필수입니다.")
+    @Positive(message = "잘못된 카테고리 번호입니다.")
+    private Long categoryId;
+
+    private String memo;
+
+    @NotNull(message = "합계 제외 여부는 필수입니다.")
+    private Boolean excludeTotalExpense;
+
+    public Expense toExpenseWithCategory(Category category) {
+        return Expense.builder()
+                .exclude(excludeTotalExpense)
+                .category(category)
+                .expenseAt(expenseDateTime)
+                .money(new Money(expenseMount))
+                .memo(memo)
+                .build();
+    }
+
+    @Builder
+    public ModifyExpenseRequest(final Integer expenseMount, final LocalDateTime expenseDateTime, final Long categoryId, final String memo,
+            final Boolean excludeTotalExpense) {
+        this.expenseMount = expenseMount;
+        this.expenseDateTime = expenseDateTime;
+        this.categoryId = categoryId;
+        this.memo = memo;
+        this.excludeTotalExpense = excludeTotalExpense;
+    }
+}

--- a/src/main/java/jaringobi/domain/budget/Money.java
+++ b/src/main/java/jaringobi/domain/budget/Money.java
@@ -23,4 +23,12 @@ public class Money {
             throw new LowBudgetException();
         }
     }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public boolean isSameAs(Money money) {
+        return amount == money.getAmount();
+    }
 }

--- a/src/main/java/jaringobi/domain/category/Category.java
+++ b/src/main/java/jaringobi/domain/category/Category.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jaringobi.domain.BaseTimeEntity;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,5 +27,12 @@ public class Category extends BaseTimeEntity {
     public Category(Long id, String name) {
         this.id = id;
         this.name = name;
+    }
+
+    public boolean isSameAs(Category category) {
+        if (Objects.isNull(category)) {
+            return false;
+        }
+        return id.equals(category.id);
     }
 }

--- a/src/main/java/jaringobi/domain/expense/Expense.java
+++ b/src/main/java/jaringobi/domain/expense/Expense.java
@@ -66,12 +66,15 @@ public class Expense extends BaseTimeEntity {
             final LocalDateTime expenseAt, final Boolean exclude) {
         verifyNonNullArgument(money, category, expenseAt);
         this.id = id;
-        this.memo = memo;
+        this.expenseAt = expenseAt;
+        if (Objects.nonNull(memo)) {
+            setMemo(memo);
+        }
+
         if (Objects.nonNull(money)) {
             setMoney(money);
         }
 
-        this.expenseAt = expenseAt;
         if (Objects.nonNull(exclude)) {
             setExclude(exclude);
         }
@@ -82,6 +85,12 @@ public class Expense extends BaseTimeEntity {
 
         if (Objects.nonNull(category)) {
             setCategory(category);
+        }
+    }
+
+    private void setMemo(String memo) {
+        if (Objects.nonNull(memo)) {
+            this.memo = memo;
         }
     }
 
@@ -114,13 +123,13 @@ public class Expense extends BaseTimeEntity {
     }
 
     public void modify(Expense expense) {
-        this.memo = expense.memo;
+        if (Objects.nonNull(expense.memo)) {
+            this.memo = expense.memo;
+        }
         this.money = new Money(expense.money.getAmount());
         this.expenseAt = expense.expenseAt;
         this.isExcludeInTotal = expense.isExcludeInTotal;
-        if (Objects.nonNull(expense.getCategory())) {
-            setCategory(expense.getCategory());
-        }
+        this.category = expense.getCategory();
     }
 
     private void setCategory(Category category) {

--- a/src/main/java/jaringobi/domain/expense/Expense.java
+++ b/src/main/java/jaringobi/domain/expense/Expense.java
@@ -117,6 +117,7 @@ public class Expense extends BaseTimeEntity {
         this.memo = expense.memo;
         this.money = new Money(expense.money.getAmount());
         this.expenseAt = expense.expenseAt;
+        this.isExcludeInTotal = expense.isExcludeInTotal;
         if (Objects.nonNull(expense.getCategory())) {
             setCategory(expense.getCategory());
         }
@@ -147,5 +148,9 @@ public class Expense extends BaseTimeEntity {
 
     public LocalDateTime getExpenseAt() {
         return expenseAt;
+    }
+
+    public boolean isExcludeInTotal() {
+        return isExcludeInTotal;
     }
 }

--- a/src/main/java/jaringobi/domain/expense/Expense.java
+++ b/src/main/java/jaringobi/domain/expense/Expense.java
@@ -67,7 +67,6 @@ public class Expense extends BaseTimeEntity {
         verifyNonNullArgument(money, category, expenseAt);
         this.id = id;
         this.memo = memo;
-
         if (Objects.nonNull(money)) {
             setMoney(money);
         }
@@ -79,6 +78,10 @@ public class Expense extends BaseTimeEntity {
 
         if (Objects.nonNull(user)) {
             setUser(user);
+        }
+
+        if (Objects.nonNull(category)) {
+            setCategory(category);
         }
     }
 
@@ -115,11 +118,16 @@ public class Expense extends BaseTimeEntity {
         this.money = new Money(expense.money.getAmount());
         this.expenseAt = expense.expenseAt;
         if (Objects.nonNull(expense.getCategory())) {
-            setCategory(category);
+            setCategory(expense.getCategory());
         }
     }
 
     private void setCategory(Category category) {
+        if (Objects.isNull(this.category)) {
+            this.category = category;
+            return;
+        }
+
         if (!this.category.isSameAs(category)) {
             this.category = category;
         }

--- a/src/main/java/jaringobi/domain/user/User.java
+++ b/src/main/java/jaringobi/domain/user/User.java
@@ -35,9 +35,10 @@ public class User extends BaseTimeEntity {
     private boolean isDeleted = false;
 
     @Builder
-    public User(String username, String password) {
+    public User(Long id, String username, String password) {
         Assert.hasText(username, "username must not be empty");
         Assert.hasText(password, "password must not be empty");
+        this.id = id;
         this.username = username;
         this.password = password;
     }
@@ -54,5 +55,9 @@ public class User extends BaseTimeEntity {
 
     public Long getId() {
         return id;
+    }
+
+    public boolean isSame(AppUser appUser) {
+        return id.equals(appUser.userId());
     }
 }

--- a/src/main/java/jaringobi/exception/ErrorType.java
+++ b/src/main/java/jaringobi/exception/ErrorType.java
@@ -4,10 +4,11 @@ package jaringobi.exception;
 import jaringobi.exception.budget.InvalidBudgetException;
 import jaringobi.exception.budget.LowBudgetException;
 import jaringobi.exception.category.CategoryNotFoundException;
+import jaringobi.exception.expense.ExpenseNotFoundException;
 import jaringobi.exception.expense.ExpenseNullArgumentException;
 import jaringobi.exception.expense.ExpenseNullUserException;
-import jaringobi.exception.user.UserNotFoundException;
 import jaringobi.exception.user.PasswordNotMatchedException;
+import jaringobi.exception.user.UserNotFoundException;
 import jaringobi.exception.user.UsernameDuplicatedException;
 import java.util.Arrays;
 import java.util.List;
@@ -28,6 +29,7 @@ public enum ErrorType {
 
     E001("E001", "필수 지출 정보를 입력바랍니다. 정보 생성 시 (지출 금액, 지출 일, 지출 카테고리)", ExpenseNullArgumentException.class, HttpStatus.BAD_REQUEST),
     E002("E002", "지출 추가 시 유저 정보는 필수입니다.", ExpenseNullUserException.class, HttpStatus.BAD_REQUEST),
+    E003("E003", "존재하지 않는 지출 정보입니다.", ExpenseNotFoundException.class, HttpStatus.NOT_FOUND),
 
     C001("C001", "존재하지 않는 카테고리 입니다.", CategoryNotFoundException.class, HttpStatus.BAD_REQUEST);
 

--- a/src/main/java/jaringobi/exception/auth/AuthenticationErrorType.java
+++ b/src/main/java/jaringobi/exception/auth/AuthenticationErrorType.java
@@ -11,7 +11,9 @@ public enum AuthenticationErrorType {
 
     FORBIDDEN("AUTH_00", "인증이 필요한 접근입니다.", AuthenticationException.class),
     EXPIRED_AT("AUTH_01", "엑세스 토큰이 만료되었습니다.", AccessTokenExpiredException.class),
-    INVALID_TOKEN("AUTH_02", "유효하지 않은 토큰입니다.", InvalidTokenException.class);
+    INVALID_TOKEN("AUTH_02", "유효하지 않은 토큰입니다.", InvalidTokenException.class),
+    NO_PERMISSION("AUTH_03", "해당 작업을 수행할 권한이 없습니다.", NoPermissionException.class);
+
 
     private final String code;
     private final String message;

--- a/src/main/java/jaringobi/exception/auth/NoPermissionException.java
+++ b/src/main/java/jaringobi/exception/auth/NoPermissionException.java
@@ -1,0 +1,5 @@
+package jaringobi.exception.auth;
+
+public class NoPermissionException extends AuthenticationException {
+
+}

--- a/src/main/java/jaringobi/exception/expense/ExpenseNotFoundException.java
+++ b/src/main/java/jaringobi/exception/expense/ExpenseNotFoundException.java
@@ -1,0 +1,7 @@
+package jaringobi.exception.expense;
+
+import jaringobi.exception.BudgetGlobalException;
+
+public class ExpenseNotFoundException extends BudgetGlobalException {
+
+}

--- a/src/main/java/jaringobi/service/ExpenseService.java
+++ b/src/main/java/jaringobi/service/ExpenseService.java
@@ -1,6 +1,7 @@
 package jaringobi.service;
 
 import jaringobi.controller.request.AddExpenseRequest;
+import jaringobi.controller.request.ModifyExpenseRequest;
 import jaringobi.controller.response.AddExpenseNoResponse;
 import jaringobi.domain.budget.Money;
 import jaringobi.domain.category.Category;
@@ -10,7 +11,9 @@ import jaringobi.domain.expense.ExpenseRepository;
 import jaringobi.domain.user.AppUser;
 import jaringobi.domain.user.User;
 import jaringobi.domain.user.UserRepository;
+import jaringobi.exception.auth.NoPermissionException;
 import jaringobi.exception.category.CategoryNotFoundException;
+import jaringobi.exception.expense.ExpenseNotFoundException;
 import jaringobi.exception.user.UserNotFoundException;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -26,12 +29,32 @@ public class ExpenseService {
     private final CategoryRepository categoryRepository;
 
     @Transactional
-    public AddExpenseNoResponse addExpense(AddExpenseRequest addExpenseRequest,final AppUser appUser) {
+    public AddExpenseNoResponse addExpense(AddExpenseRequest addExpenseRequest, final AppUser appUser) {
         final User user = findUser(appUser);
         final Category category = findCategory(addExpenseRequest.getCategoryId());
         Expense expense = convertToExpense(addExpenseRequest, user, category);
         Expense savedExpense = expenseRepository.save(expense);
         return AddExpenseNoResponse.of(savedExpense);
+    }
+
+    @Transactional
+    public void modifyExpense(ModifyExpenseRequest modifyExpenseRequest, final Long expenseId, final AppUser appUser) {
+        Expense expense = findExpenseOwnerOf(appUser, expenseId);
+        final Category category = findCategory(modifyExpenseRequest.getCategoryId());
+        expense.modify(modifyExpenseRequest.toExpenseWithCategory(category));
+    }
+
+    private Expense findExpenseOwnerOf(AppUser appUser, Long expenseId) {
+        final Expense expense = findExpense(expenseId);
+        if (!expense.isOwnerOf(appUser)) {
+            throw new NoPermissionException();
+        }
+        return expense;
+    }
+
+    private Expense findExpense(Long expenseId) {
+        return expenseRepository.findById(expenseId)
+                .orElseThrow(ExpenseNotFoundException::new);
     }
 
     private Expense convertToExpense(AddExpenseRequest addExpenseRequest, User user, Category category) {

--- a/src/test/java/jaringobi/acceptance/APITest.java
+++ b/src/test/java/jaringobi/acceptance/APITest.java
@@ -1,18 +1,22 @@
 package jaringobi.acceptance;
 
+import static java.util.Arrays.stream;
+
 import io.restassured.RestAssured;
 import jaringobi.domain.user.User;
 import jaringobi.domain.user.UserRepository;
 import jaringobi.jwt.TokenProvider;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-public class ApiTest{
+public class APITest {
 
     @LocalServerPort
     private int port;
@@ -27,26 +31,38 @@ public class ApiTest{
     private TokenProvider tokenProvider;
 
     protected String accessToken;
+    protected String anotherUserAccessToken;
 
     @BeforeEach
-    void setUp() {
-        if(RestAssured.port == RestAssured.UNDEFINED_PORT) {
+    void setUp() throws NotFoundException {
+        if (RestAssured.port == RestAssured.UNDEFINED_PORT) {
             RestAssured.port = port;
             databaseCleaner.afterPropertiesSet();
         }
         databaseCleaner.execute();
 
         // setup Authentication
-        User savedUser = getSavedUser();
-        accessToken = tokenProvider.issueAccessToken(savedUser.getId());
+        saveUsersByIds(1L, 2L);
+        accessToken = tokenProvider.issueAccessToken(findUser(1L).getId());
+        anotherUserAccessToken = tokenProvider.issueAccessToken(findUser(2L).getId());
     }
 
-    private User getSavedUser() {
-        User savedUser = userRepository.save(User.builder()
-                .username("testuser123")
-                .password("testuser123!")
-                .build());
-        return savedUser;
+    private void saveUsersByIds(Long... ids) {
+        List<User> users = stream(ids).map(this::createUser).toList();
+        userRepository.saveAll(users);
+    }
+
+    private User createUser(Long id) {
+        return User.builder()
+                .id(id)
+                .username("testuser123" + id)
+                .password("testuser123!" + id)
+                .build();
+    }
+
+    private User findUser(Long id) throws NotFoundException {
+        return userRepository.findById(id)
+                .orElseThrow(NotFoundException::new);
     }
 
     @AfterEach

--- a/src/test/java/jaringobi/acceptance/budget/BudgetAPI.java
+++ b/src/test/java/jaringobi/acceptance/budget/BudgetAPI.java
@@ -1,19 +1,25 @@
-package jaringobi.acceptance.category;
+package jaringobi.acceptance.budget;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.springframework.http.MediaType;
 
-public class CategoryApi {
+public class BudgetAPI {
 
-    public static ExtractableResponse<Response> 카테고리목록요청() {
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER = "Bearer ";
+
+    public static ExtractableResponse<Response> 예산설정(String body, String token) {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
-                .get("/api/v1/categories")
+                .header(AUTHORIZATION, BEARER + token)
+                .body(body)
+                .post("/api/v1/budget")
                 .andReturn()
                 .then()
                 .log().all().extract();
     }
+
 }

--- a/src/test/java/jaringobi/acceptance/budget/BudgetAPITest.java
+++ b/src/test/java/jaringobi/acceptance/budget/BudgetAPITest.java
@@ -4,13 +4,13 @@ package jaringobi.acceptance.budget;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.path.json.JsonPath;
-import jaringobi.acceptance.ApiTest;
+import jaringobi.acceptance.APITest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("예산 API 테스트")
-public class BudgetApiTest extends ApiTest {
+public class BudgetAPITest extends APITest {
 
     @Nested
     @DisplayName("[예산 설정] /api/v1/budget ")
@@ -36,7 +36,7 @@ public class BudgetApiTest extends ApiTest {
                     }
                     """;
             // When
-            var response = BudgetApi.예산설정(body, accessToken);
+            var response = BudgetAPI.예산설정(body, accessToken);
 
             // Then
             assertThat(response.response().statusCode()).isEqualTo(201);
@@ -62,7 +62,7 @@ public class BudgetApiTest extends ApiTest {
                     }
                     """;
             // When
-            var response = BudgetApi.예산설정(body, accessToken);
+            var response = BudgetAPI.예산설정(body, accessToken);
             JsonPath jsonPath = response.jsonPath();
 
             // Then
@@ -82,7 +82,7 @@ public class BudgetApiTest extends ApiTest {
                     }
                     """;
             // When
-            var response = BudgetApi.예산설정(body, accessToken);
+            var response = BudgetAPI.예산설정(body, accessToken);
             JsonPath jsonPath = response.jsonPath();
 
             // Then
@@ -112,7 +112,7 @@ public class BudgetApiTest extends ApiTest {
                     }
                     """;
             // When
-            var response = BudgetApi.예산설정(body, accessToken);
+            var response = BudgetAPI.예산설정(body, accessToken);
             JsonPath jsonPath = response.jsonPath();
 
             // Then

--- a/src/test/java/jaringobi/acceptance/category/CategoryAPI.java
+++ b/src/test/java/jaringobi/acceptance/category/CategoryAPI.java
@@ -1,25 +1,19 @@
-package jaringobi.acceptance.budget;
+package jaringobi.acceptance.category;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.springframework.http.MediaType;
 
-public class BudgetApi {
+public class CategoryAPI {
 
-    private static final String AUTHORIZATION = "Authorization";
-    private static final String BEARER = "Bearer ";
-
-    public static ExtractableResponse<Response> 예산설정(String body, String token) {
+    public static ExtractableResponse<Response> 카테고리목록요청() {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
-                .header(AUTHORIZATION, BEARER + token)
-                .body(body)
-                .post("/api/v1/budget")
+                .get("/api/v1/categories")
                 .andReturn()
                 .then()
                 .log().all().extract();
     }
-
 }

--- a/src/test/java/jaringobi/acceptance/category/CategoryAPITest.java
+++ b/src/test/java/jaringobi/acceptance/category/CategoryAPITest.java
@@ -2,18 +2,18 @@ package jaringobi.acceptance.category;
 
 import static org.assertj.core.api.Assertions.*;
 
-import jaringobi.acceptance.ApiTest;
+import jaringobi.acceptance.APITest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 @DisplayName("카테고리 API 테스트")
-public class CategoryApiTest extends ApiTest {
+public class CategoryAPITest extends APITest {
 
     @Test
     @DisplayName("성공 : [카테고리 목록조회] /api/v1/categories")
     void test() {
-        var response = CategoryApi.카테고리목록요청();
+        var response = CategoryAPI.카테고리목록요청();
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 

--- a/src/test/java/jaringobi/acceptance/expense/ExpenseAPI.java
+++ b/src/test/java/jaringobi/acceptance/expense/ExpenseAPI.java
@@ -5,7 +5,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.springframework.http.MediaType;
 
-public class ExpenseApi {
+public class ExpenseAPI {
 
     private static final String AUTHORIZATION = "Authorization";
     private static final String BEARER = "Bearer ";
@@ -17,6 +17,18 @@ public class ExpenseApi {
                 .header(AUTHORIZATION, BEARER + token)
                 .body(body)
                 .post("/api/v1/expenditures")
+                .andReturn()
+                .then()
+                .log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 지출수정요청(Long id, String body, String token) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .header(AUTHORIZATION, BEARER + token)
+                .body(body)
+                .put("/api/v1/expenditures/{id}", id)
                 .andReturn()
                 .then()
                 .log().all().extract();

--- a/src/test/java/jaringobi/acceptance/expense/ExpenseCreateAPITest.java
+++ b/src/test/java/jaringobi/acceptance/expense/ExpenseCreateAPITest.java
@@ -1,0 +1,211 @@
+package jaringobi.acceptance.expense;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.path.json.JsonPath;
+import jaringobi.acceptance.APITest;
+import jaringobi.domain.expense.ExpenseRepository;
+import jaringobi.exception.ErrorType;
+import jaringobi.exception.auth.AuthenticationErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("지출 API 테스트")
+public class ExpenseCreateAPITest extends APITest {
+
+    @Autowired
+    ExpenseRepository expenseRepository;
+
+    @Nested
+    @DisplayName("[지출 등록] /api/v1/expenditures ")
+    class CreateApiTest {
+
+        @Test
+        @DisplayName("성공 200")
+        void success() {
+            var body = """
+                    {
+                        "memo": "친구들이랑 점심 짬뽕",
+                        "categoryId": 3,
+                        "expenseMount": 10000,
+                        "expenseDateTime": "2023-10-02T02:11:00",
+                        "excludeTotalExpense": true
+                    }
+                    """;
+
+            // When
+            var response = ExpenseAPI.지출추가요청(body, accessToken);
+            JsonPath jsonPath = response.jsonPath();
+
+            // Then
+            assertThat(response.response().statusCode()).isEqualTo(200);
+            assertThat(jsonPath.getString("code")).isEqualTo("200");
+            assertThat(jsonPath.getString("data.expenseNo")).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("성공 200 - 합계여부를 보내지 않는 경우")
+        void successNullExcludeTotalExpense() {
+            var body = """
+                    {
+                        "memo": "친구들이랑 점심 짬뽕",
+                        "categoryId": 3,
+                        "expenseMount": 10000,
+                        "expenseDateTime": "2023-10-02T02:11:00"
+                    }
+                    """;
+
+            // When
+            var response = ExpenseAPI.지출추가요청(body, accessToken);
+            JsonPath jsonPath = response.jsonPath();
+
+            // Then
+            assertThat(response.response().statusCode()).isEqualTo(200);
+            assertThat(jsonPath.getString("code")).isEqualTo("200");
+            assertThat(jsonPath.getString("data.expenseNo")).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("실패 400 - 지출 일이 없을 경우")
+        void failExpenseDateTimeIsNull() {
+            var body = """
+                    {
+                        "memo": "친구들이랑 점심 짬뽕",
+                        "categoryId": 3,
+                        "expenseMount": 10000
+                    }
+                    """;
+
+            // When
+            var response = ExpenseAPI.지출추가요청(body, accessToken);
+            JsonPath jsonPath = response.jsonPath();
+
+            // Then
+            assertThat(response.response().statusCode()).isEqualTo(400);
+            assertThat(jsonPath.getString("code")).isEqualTo(ErrorType.E001.getCode());
+            assertThat(jsonPath.getString("errorFields[0].field")).isEqualTo("expenseDateTime");
+            assertThat(jsonPath.getString("errorFields[0].message")).contains("지출일은 필수입니다.");
+        }
+
+        @Test
+        @DisplayName("실패 400 - 카테고리를 입력하지 않을경우")
+        void failCategoryIsNull() {
+            var body = """
+                    {
+                        "memo": "친구들이랑 점심 짬뽕",
+                        "expenseMount": 10000,
+                        "expenseDateTime": "2023-10-02T02:11:00"
+                    }
+                    """;
+
+            // When
+            var response = ExpenseAPI.지출추가요청(body, accessToken);
+            JsonPath jsonPath = response.jsonPath();
+
+            // Then
+            assertThat(response.response().statusCode()).isEqualTo(400);
+            assertThat(jsonPath.getString("code")).isEqualTo(ErrorType.E001.getCode());
+            assertThat(jsonPath.getString("errorFields[0].field")).isEqualTo("categoryId");
+            assertThat(jsonPath.getString("errorFields[0].message")).contains("카테고리는 필수입니다.");
+        }
+
+        @ParameterizedTest
+        @DisplayName("실패 400 - 카테고리가 음수 또는 0인 경우")
+        @ValueSource(ints = {-1, 0})
+        void failCategoryIsNegativeOrZero(int categoryId) {
+            var body = String.format("""
+                    {
+                        "memo": "친구들이랑 점심 짬뽕",
+                        "expenseMount": 10000,
+                        "categoryId": %d,
+                        "expenseDateTime": "2023-10-02T02:11:00"
+                    }
+                    """, categoryId);
+
+            // When
+            var response = ExpenseAPI.지출추가요청(body, accessToken);
+            JsonPath jsonPath = response.jsonPath();
+
+            // Then
+            assertThat(response.response().statusCode()).isEqualTo(400);
+            assertThat(jsonPath.getString("code")).isEqualTo(ErrorType.E001.getCode());
+            assertThat(jsonPath.getString("errorFields[0].field")).isEqualTo("categoryId");
+            assertThat(jsonPath.getString("errorFields[0].message")).contains("잘못된 카테고리 번호입니다.");
+        }
+
+
+        @Test
+        @DisplayName("실패 400 - 지출금액이 없는 경우")
+        void failExpenseMountIsNull() {
+            var body = """
+                    {
+                        "memo": "친구들이랑 점심 짬뽕",
+                        "categoryId": 1,
+                        "expenseDateTime": "2023-10-02T02:11:00"
+                    }
+                    """;
+
+            // When
+            var response = ExpenseAPI.지출추가요청(body, accessToken);
+            JsonPath jsonPath = response.jsonPath();
+
+            // Then
+            assertThat(response.response().statusCode()).isEqualTo(400);
+            assertThat(jsonPath.getString("code")).isEqualTo(ErrorType.E001.getCode());
+            assertThat(jsonPath.getString("errorFields[0].field")).isEqualTo("expenseMount");
+            assertThat(jsonPath.getString("errorFields[0].message")).contains("지출 금액은 필수입니다.");
+        }
+
+        @ParameterizedTest
+        @DisplayName("실패 400 - 지출금액이 음수 또는 0인 경우")
+        @ValueSource(ints = {-1, 0})
+        void failExpenseMountIsNegativeOrZero(int amount) {
+            var body = String.format("""
+                    {
+                        "memo": "친구들이랑 점심 짬뽕",
+                        "expenseMount": %d,
+                        "categoryId": 1,
+                        "expenseDateTime": "2023-10-02T02:11:00"
+                    }
+                    """, amount);
+
+            // When
+            var response = ExpenseAPI.지출추가요청(body, accessToken);
+            JsonPath jsonPath = response.jsonPath();
+
+            // Then
+            assertThat(response.response().statusCode()).isEqualTo(400);
+            assertThat(jsonPath.getString("code")).isEqualTo(ErrorType.E001.getCode());
+            assertThat(jsonPath.getString("errorFields[0].field")).isEqualTo("expenseMount");
+            assertThat(jsonPath.getString("errorFields[0].message")).contains("지출 금액은 최소 0원 보다 커야합니다.");
+        }
+
+
+        @Test
+        @DisplayName("실패 403 - 토큰 없이 접근")
+        void failNonAuthenticatedUser() {
+            var body = """
+                    {
+                        "memo": "친구들이랑 점심 짬뽕",
+                        "categoryId": 3,
+                        "expenseMount": 10000,
+                        "expenseDateTime": "2023-10-02T02:11:00",
+                        "excludeTotalExpense": true
+                    }
+                    """;
+
+            // When
+            var response = ExpenseAPI.지출추가요청(body, null);
+            JsonPath jsonPath = response.jsonPath();
+
+            // Then
+            assertThat(response.response().statusCode()).isEqualTo(403);
+            assertThat(jsonPath.getString("code")).isEqualTo(AuthenticationErrorType.INVALID_TOKEN.getCode());
+            assertThat(jsonPath.getString("message")).isEqualTo(AuthenticationErrorType.INVALID_TOKEN.getMessage());
+        }
+    }
+}

--- a/src/test/java/jaringobi/acceptance/expense/ExpenseModifyAPITest.java
+++ b/src/test/java/jaringobi/acceptance/expense/ExpenseModifyAPITest.java
@@ -3,65 +3,175 @@ package jaringobi.acceptance.expense;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.path.json.JsonPath;
-import jaringobi.acceptance.ApiTest;
+import jaringobi.acceptance.APITest;
+import jaringobi.domain.expense.Expense;
+import jaringobi.domain.expense.ExpenseRepository;
+import jaringobi.domain.user.UserRepository;
 import jaringobi.exception.ErrorType;
 import jaringobi.exception.auth.AuthenticationErrorType;
+import jaringobi.exception.expense.ExpenseNotFoundException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
 
-@DisplayName("지출 API 테스트")
-public class ExpenseApiTest extends ApiTest {
+@DisplayName("[지출 수정] /api/v1/expenditures/{id}")
+public class ExpenseModifyAPITest extends APITest {
+
+    @Autowired
+    ExpenseRepository expenseRepository;
+
+    @Autowired
+    UserRepository userRepository;
 
     @Nested
-    @DisplayName("[지출 등록] /api/v1/expenditures ")
-    class CreateApiTest {
+    @DisplayName("[지출 수정] /api/v1/expenditures/{id} ")
+    class ModifyApiTest {
 
-        @Test
-        @DisplayName("성공 200")
-        void success() {
+        @BeforeEach
+        void setUp() {
+            // Given
             var body = """
                     {
                         "memo": "친구들이랑 점심 짬뽕",
-                        "categoryId": 3,
+                        "categoryId": 1,
                         "expenseMount": 10000,
                         "expenseDateTime": "2023-10-02T02:11:00",
                         "excludeTotalExpense": true
                     }
                     """;
-
-            // When
-            var response = ExpenseApi.지출추가요청(body, accessToken);
-            JsonPath jsonPath = response.jsonPath();
-
-            // Then
-            assertThat(response.response().statusCode()).isEqualTo(200);
-            assertThat(jsonPath.getString("code")).isEqualTo("200");
-            assertThat(jsonPath.getString("data.expenseNo")).isNotEmpty();
+            ExpenseAPI.지출추가요청(body, accessToken);
         }
 
         @Test
-        @DisplayName("성공 200 - 합계여부를 보내지 않는 경우")
+        @DisplayName("성공 204 - 메모도 같이 수정")
+        void success() {
+            var modifyBody = """
+                    {
+                        "memo": "친구들이랑 점심 탕수육",
+                        "categoryId": 2,
+                        "expenseMount": 15000,
+                        "expenseDateTime": "2023-01-01T00:00:00",
+                        "excludeTotalExpense": false
+                    }
+                    """;
+            // When
+            var response = ExpenseAPI.지출수정요청(1L, modifyBody, accessToken);
+            Expense expense = findExpense();
+
+            // Then
+            assertThat(response.response().statusCode()).isEqualTo(204);
+            assertThat(expense.getCategory().getId()).isEqualTo(2L);
+            assertThat(expense.getExpenseAt()).isEqualTo(LocalDateTime.of(2023, 01, 01, 0, 0, 0));
+            assertThat(expense.getMemo()).isEqualTo("친구들이랑 점심 탕수육");
+            assertThat(expense.isExcludeInTotal()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공 204 - 메모는 수정 하지 않음")
+        void successNoMemo() {
+            var modifyBody = """
+                    {
+                        "categoryId": 2,
+                        "expenseMount": 15000,
+                        "expenseDateTime": "2023-01-01T00:00:00",
+                        "excludeTotalExpense": false
+                    }
+                    """;
+            // When
+            var response = ExpenseAPI.지출수정요청(1L, modifyBody, accessToken);
+            Expense expense = findExpense();
+
+            // Then
+            assertThat(response.response().statusCode()).isEqualTo(204);
+            assertThat(expense.getCategory().getId()).isEqualTo(2L);
+            assertThat(expense.getExpenseAt()).isEqualTo(LocalDateTime.of(2023, 01, 01, 0, 0, 0));
+            assertThat(expense.getMemo()).isEqualTo("친구들이랑 점심 짬뽕");
+            assertThat(expense.isExcludeInTotal()).isFalse();
+        }
+
+        @Test
+        @DisplayName("실패 403 - 다른 유저가 지출 수정")
+        void failNoPermission() {
+            var modifyBody = """
+                    {
+                        "memo": "친구들이랑 점심 탕수육",
+                        "categoryId": 2,
+                        "expenseMount": 15000,
+                        "expenseDateTime": "2023-01-01T00:00:00",
+                        "excludeTotalExpense": false
+                    }
+                    """;
+            // When
+            var response = ExpenseAPI.지출수정요청(1L, modifyBody, anotherUserAccessToken);
+
+            // Then
+            assertThat(response.response().statusCode()).isEqualTo(403);
+        }
+
+        @Test
+        @DisplayName("실패 404 - 존재하지 않는 지출 수정 요청")
+        void failNoExistExpense() {
+            var modifyBody = """
+                    {
+                        "memo": "친구들이랑 점심 탕수육",
+                        "categoryId": 382,
+                        "expenseMount": 15000,
+                        "expenseDateTime": "2023-01-01T00:00:00",
+                        "excludeTotalExpense": false
+                    }
+                    """;
+            // When
+            var response = ExpenseAPI.지출수정요청(1L, modifyBody, accessToken);
+
+            // Then
+            assertThat(response.response().statusCode()).isEqualTo(400);
+        }
+
+        @Test
+        @DisplayName("실패 400 - 존재하지 않는 카테고리로 수정 요청")
+        void failNoExistCategory() {
+            var modifyBody = """
+                    {
+                        "memo": "친구들이랑 점심 탕수육",
+                        "categoryId": 382,
+                        "expenseMount": 15000,
+                        "expenseDateTime": "2023-01-01T00:00:00",
+                        "excludeTotalExpense": false
+                    }
+                    """;
+            // When
+            var response = ExpenseAPI.지출수정요청(1L, modifyBody, accessToken);
+
+            // Then
+            assertThat(response.response().statusCode()).isEqualTo(400);
+        }
+
+        @Test
+        @DisplayName("실패 400 - 합계여부를 보내지 않는 경우")
         void successNullExcludeTotalExpense() {
             var body = """
                     {
-                        "memo": "친구들이랑 점심 짬뽕",
-                        "categoryId": 3,
-                        "expenseMount": 10000,
-                        "expenseDateTime": "2023-10-02T02:11:00"
+                        "memo": "친구들이랑 점심 탕수육",
+                        "categoryId": 1,
+                        "expenseMount": 15000,
+                        "expenseDateTime": "2023-01-01T00:00:00"
                     }
                     """;
 
             // When
-            var response = ExpenseApi.지출추가요청(body, accessToken);
+            var response = ExpenseAPI.지출수정요청(1L, body, accessToken);
             JsonPath jsonPath = response.jsonPath();
 
             // Then
-            assertThat(response.response().statusCode()).isEqualTo(200);
-            assertThat(jsonPath.getString("code")).isEqualTo("200");
-            assertThat(jsonPath.getString("data.expenseNo")).isNotEmpty();
+            assertThat(response.response().statusCode()).isEqualTo(400);
+            assertThat(jsonPath.getString("code")).isEqualTo(ErrorType.E001.getCode());
+            assertThat(jsonPath.getString("errorFields[0].field")).isEqualTo("excludeTotalExpense");
+            assertThat(jsonPath.getString("errorFields[0].message")).contains("합계 제외 여부는 필수입니다.");
         }
 
         @Test
@@ -76,7 +186,7 @@ public class ExpenseApiTest extends ApiTest {
                     """;
 
             // When
-            var response = ExpenseApi.지출추가요청(body, accessToken);
+            var response = ExpenseAPI.지출수정요청(1L, body, accessToken);
             JsonPath jsonPath = response.jsonPath();
 
             // Then
@@ -98,7 +208,7 @@ public class ExpenseApiTest extends ApiTest {
                     """;
 
             // When
-            var response = ExpenseApi.지출추가요청(body, accessToken);
+            var response = ExpenseAPI.지출추가요청(body, accessToken);
             JsonPath jsonPath = response.jsonPath();
 
             // Then
@@ -122,7 +232,7 @@ public class ExpenseApiTest extends ApiTest {
                     """, categoryId);
 
             // When
-            var response = ExpenseApi.지출추가요청(body, accessToken);
+            var response = ExpenseAPI.지출추가요청(body, accessToken);
             JsonPath jsonPath = response.jsonPath();
 
             // Then
@@ -145,7 +255,7 @@ public class ExpenseApiTest extends ApiTest {
                     """;
 
             // When
-            var response = ExpenseApi.지출추가요청(body, accessToken);
+            var response = ExpenseAPI.지출추가요청(body, accessToken);
             JsonPath jsonPath = response.jsonPath();
 
             // Then
@@ -169,7 +279,7 @@ public class ExpenseApiTest extends ApiTest {
                     """, amount);
 
             // When
-            var response = ExpenseApi.지출추가요청(body, accessToken);
+            var response = ExpenseAPI.지출추가요청(body, accessToken);
             JsonPath jsonPath = response.jsonPath();
 
             // Then
@@ -194,7 +304,7 @@ public class ExpenseApiTest extends ApiTest {
                     """;
 
             // When
-            var response = ExpenseApi.지출추가요청(body, null);
+            var response = ExpenseAPI.지출수정요청(1L, body, null);
             JsonPath jsonPath = response.jsonPath();
 
             // Then
@@ -202,5 +312,11 @@ public class ExpenseApiTest extends ApiTest {
             assertThat(jsonPath.getString("code")).isEqualTo(AuthenticationErrorType.INVALID_TOKEN.getCode());
             assertThat(jsonPath.getString("message")).isEqualTo(AuthenticationErrorType.INVALID_TOKEN.getMessage());
         }
+
+    }
+
+    private Expense findExpense() {
+        return expenseRepository.findById(1L)
+                .orElseThrow(ExpenseNotFoundException::new);
     }
 }

--- a/src/test/java/jaringobi/acceptance/user/UserAPI.java
+++ b/src/test/java/jaringobi/acceptance/user/UserAPI.java
@@ -5,7 +5,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.springframework.http.MediaType;
 
-public class UserApi {
+public class UserAPI {
 
     public static ExtractableResponse<Response> 회원가입요청(String body) {
         return RestAssured.given().log().all()

--- a/src/test/java/jaringobi/acceptance/user/UserLoginAPITest.java
+++ b/src/test/java/jaringobi/acceptance/user/UserLoginAPITest.java
@@ -3,13 +3,12 @@ package jaringobi.acceptance.user;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.path.json.JsonPath;
-import jaringobi.acceptance.ApiTest;
+import jaringobi.acceptance.APITest;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("[로그인] API 테스트 : /api/v1/login ")
-public class UserLoginApiTest extends ApiTest {
+public class UserLoginAPITest extends APITest {
 
     @Test
     @DisplayName("성공 200")
@@ -21,7 +20,7 @@ public class UserLoginApiTest extends ApiTest {
                         "password": "password123!"
                     }
                 """;
-        UserApi.회원가입요청(signUpbody);
+        UserAPI.회원가입요청(signUpbody);
 
         String loginBody = """
                 {
@@ -31,7 +30,7 @@ public class UserLoginApiTest extends ApiTest {
                 """;
 
         // When
-        var response = UserApi.로그인요청(loginBody);
+        var response = UserAPI.로그인요청(loginBody);
         JsonPath jsonPath = response.jsonPath();
 
         // Then
@@ -53,7 +52,7 @@ public class UserLoginApiTest extends ApiTest {
                 """;
 
         // When
-        var response = UserApi.로그인요청(loginBody);
+        var response = UserAPI.로그인요청(loginBody);
 
         // Then
         assertThat(response.response().statusCode()).isEqualTo(404);
@@ -70,7 +69,7 @@ public class UserLoginApiTest extends ApiTest {
                         "password": "password123!"
                     }
                 """;
-        UserApi.회원가입요청(signUpbody);
+        UserAPI.회원가입요청(signUpbody);
 
         String loginBody = """
                 {
@@ -80,7 +79,7 @@ public class UserLoginApiTest extends ApiTest {
                 """;
 
         // When
-        var response = UserApi.로그인요청(loginBody);
+        var response = UserAPI.로그인요청(loginBody);
 
         // Then
         assertThat(response.response().statusCode()).isEqualTo(400);
@@ -97,7 +96,7 @@ public class UserLoginApiTest extends ApiTest {
                 """;
 
         // When
-        var response = UserApi.로그인요청(loginBody);
+        var response = UserAPI.로그인요청(loginBody);
         JsonPath jsonPath = response.jsonPath();
 
         // Then
@@ -119,7 +118,7 @@ public class UserLoginApiTest extends ApiTest {
                 """;
 
         // When
-        var response = UserApi.로그인요청(loginBody);
+        var response = UserAPI.로그인요청(loginBody);
         JsonPath jsonPath = response.jsonPath();
 
         // Then
@@ -142,7 +141,7 @@ public class UserLoginApiTest extends ApiTest {
                 """;
 
         // When
-        var response = UserApi.로그인요청(loginBody);
+        var response = UserAPI.로그인요청(loginBody);
         JsonPath jsonPath = response.jsonPath();
 
         // Then

--- a/src/test/java/jaringobi/acceptance/user/UserSignUpAPITest.java
+++ b/src/test/java/jaringobi/acceptance/user/UserSignUpAPITest.java
@@ -4,12 +4,12 @@ package jaringobi.acceptance.user;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.path.json.JsonPath;
-import jaringobi.acceptance.ApiTest;
+import jaringobi.acceptance.APITest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("[회원가입] API 테스트 : /api/v1/signup ")
-public class UserSignUpApiTest extends ApiTest {
+public class UserSignUpAPITest extends APITest {
 
 
     @Test
@@ -21,7 +21,7 @@ public class UserSignUpApiTest extends ApiTest {
                         "password": "password123!"
                     }
                 """;
-        var response = UserApi.회원가입요청(body);
+        var response = UserAPI.회원가입요청(body);
         assertThat(response.response().statusCode()).isEqualTo(204);
         assertThat(response.header("Content-Type")).isEqualTo("application/json");
     }
@@ -36,7 +36,7 @@ public class UserSignUpApiTest extends ApiTest {
                         "password": "password123!"
                     }
                 """;
-        UserApi.회원가입요청(body);
+        UserAPI.회원가입요청(body);
 
         // when
         String body2 = """
@@ -45,7 +45,7 @@ public class UserSignUpApiTest extends ApiTest {
                         "password": "password123!"
                     }
                 """;
-        var response = UserApi.회원가입요청(body2);
+        var response = UserAPI.회원가입요청(body2);
         JsonPath jsonPath = response.jsonPath();
 
         // then
@@ -64,7 +64,7 @@ public class UserSignUpApiTest extends ApiTest {
                         "password": "password123!"
                     }
                 """;
-        var response = UserApi.회원가입요청(body);
+        var response = UserAPI.회원가입요청(body);
         JsonPath jsonPath = response.jsonPath();
         assertThat(response.response().statusCode()).isEqualTo(400);
         assertThat(response.header("Content-Type")).isEqualTo("application/json");
@@ -81,7 +81,7 @@ public class UserSignUpApiTest extends ApiTest {
                         "password": "password123"
                     }
                 """;
-        var response = UserApi.회원가입요청(body);
+        var response = UserAPI.회원가입요청(body);
         JsonPath jsonPath = response.jsonPath();
 
         assertThat(response.response().statusCode()).isEqualTo(400);

--- a/src/test/java/jaringobi/domain/expense/ExpenseTest.java
+++ b/src/test/java/jaringobi/domain/expense/ExpenseTest.java
@@ -1,13 +1,14 @@
 package jaringobi.domain.expense;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import jaringobi.domain.budget.Money;
 import jaringobi.domain.category.Category;
+import jaringobi.domain.user.AppUser;
 import jaringobi.domain.user.User;
 import jaringobi.exception.expense.ExpenseNullArgumentException;
-import jaringobi.exception.expense.ExpenseNullUserException;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,22 +33,6 @@ class ExpenseTest {
                         .build())
                 .build()
         ).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("User 없이 Builder 로 Expense 객체 시 예외 던짐")
-    void throwExceptionNullUser() {
-        assertThatThrownBy(() -> Expense.builder()
-                .memo("memo")
-                .money(new Money(100))
-                .user(null)
-                .expenseAt(LocalDateTime.now())
-                .category(Category.builder()
-                        .id(1L)
-                        .name("간식")
-                        .build())
-                .build()
-        ).isInstanceOf(ExpenseNullUserException.class);
     }
 
     @Test
@@ -98,5 +83,99 @@ class ExpenseTest {
                         .build())
                 .build()
         ).isInstanceOf(ExpenseNullArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("User 와 AppUser 가 같으면 isOwnerOf 는 True 반환")
+    void returnTrueIsOwnerOfUserIdEqualAppUser() {
+        User user = User.builder()
+                .id(1L)
+                .username("username")
+                .password("password123!")
+                .build();
+        Expense expense = Expense.builder()
+                .memo("memo")
+                .money(new Money(100))
+                .user(user)
+                .expenseAt(LocalDateTime.now())
+                .category(Category.builder()
+                        .id(1L)
+                        .name("간식")
+                        .build())
+                .build();
+
+        AppUser appUser = new AppUser(1L);
+
+        // When
+        boolean isOwner = expense.isOwnerOf(appUser);
+
+        // Then
+        assertThat(isOwner).isTrue();
+    }
+
+    @Test
+    @DisplayName("User 와 AppUser 다르면 isOwnerOf 는 False 반환")
+    void returnFalseIsOwnerOfUserIdNotEqualAppUser() {
+        User user = User.builder()
+                .id(1L)
+                .username("username")
+                .password("password123!")
+                .build();
+        Expense expense = Expense.builder()
+                .memo("memo")
+                .money(new Money(100))
+                .user(user)
+                .expenseAt(LocalDateTime.now())
+                .category(Category.builder()
+                        .id(1L)
+                        .name("간식")
+                        .build())
+                .build();
+
+        AppUser appUser = new AppUser(2L);
+
+        // When
+        boolean isOwner = expense.isOwnerOf(appUser);
+
+        // Then
+        assertThat(isOwner).isFalse();
+    }
+
+    @Test
+    @DisplayName("Expense 수정 성공")
+    void modifyExpense() {
+        Expense expense = Expense.builder()
+                .memo("memo")
+                .money(new Money(100))
+                .user(User.builder()
+                        .username("username")
+                        .password("password123!")
+                        .build()
+                )
+                .expenseAt(LocalDateTime.now())
+                .category(Category.builder()
+                        .id(1L)
+                        .name("간식")
+                        .build())
+                .build();
+
+        Expense modifyExpense = Expense.builder()
+                .memo("memo2")
+                .money(new Money(100_000))
+                .expenseAt(LocalDateTime.of(2029, 12, 25, 0, 0))
+                .category(Category.builder()
+                        .id(100L)
+                        .name("기타")
+                        .build())
+                .build();
+
+        // When
+        expense.modify(modifyExpense);
+
+        // Then
+        assertThat(expense.getExpenseAt()).isEqualTo(modifyExpense.getExpenseAt());
+        assertThat(expense.getMoney().isSameAs(modifyExpense.getMoney())).isTrue();
+        assertThat(expense.getCategory().isSameAs(modifyExpense.getCategory())).isFalse();
+        assertThat(expense.getMemo()).isEqualTo(modifyExpense.getMemo());
     }
 }

--- a/src/test/java/jaringobi/domain/expense/ExpenseTest.java
+++ b/src/test/java/jaringobi/domain/expense/ExpenseTest.java
@@ -157,6 +157,7 @@ class ExpenseTest {
                         .id(1L)
                         .name("간식")
                         .build())
+                .exclude(false)
                 .build();
 
         Expense modifyExpense = Expense.builder()
@@ -167,6 +168,7 @@ class ExpenseTest {
                         .id(100L)
                         .name("기타")
                         .build())
+                .exclude(true)
                 .build();
 
         // When
@@ -175,7 +177,8 @@ class ExpenseTest {
         // Then
         assertThat(expense.getExpenseAt()).isEqualTo(modifyExpense.getExpenseAt());
         assertThat(expense.getMoney().isSameAs(modifyExpense.getMoney())).isTrue();
-        assertThat(expense.getCategory().isSameAs(modifyExpense.getCategory())).isFalse();
+        assertThat(expense.getCategory().isSameAs(modifyExpense.getCategory())).isTrue();
         assertThat(expense.getMemo()).isEqualTo(modifyExpense.getMemo());
+        assertThat(expense.isExcludeInTotal()).isEqualTo(modifyExpense.isExcludeInTotal());
     }
 }

--- a/src/test/java/jaringobi/service/ExpenseServiceTest.java
+++ b/src/test/java/jaringobi/service/ExpenseServiceTest.java
@@ -154,6 +154,7 @@ public class ExpenseServiceTest {
         assertThat(mockExpense.getCategory().getId()).isEqualTo(modifyExpenseRequest.getCategoryId());
         assertThat(mockExpense.getMoney().getAmount()).isEqualTo(modifyExpenseRequest.getExpenseMount());
         assertThat(mockExpense.getExpenseAt()).isEqualTo(modifyExpenseRequest.getExpenseDateTime());
+        assertThat(mockExpense.isExcludeInTotal()).isEqualTo(modifyExpenseRequest.getExcludeTotalExpense());
     }
 
     @Test

--- a/src/test/java/jaringobi/service/ExpenseServiceTest.java
+++ b/src/test/java/jaringobi/service/ExpenseServiceTest.java
@@ -1,5 +1,6 @@
 package jaringobi.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -7,6 +8,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jaringobi.controller.request.AddExpenseRequest;
+import jaringobi.controller.request.ModifyExpenseRequest;
+import jaringobi.controller.response.AddExpenseNoResponse;
 import jaringobi.domain.budget.Money;
 import jaringobi.domain.category.Category;
 import jaringobi.domain.category.CategoryRepository;
@@ -15,10 +18,13 @@ import jaringobi.domain.expense.ExpenseRepository;
 import jaringobi.domain.user.AppUser;
 import jaringobi.domain.user.User;
 import jaringobi.domain.user.UserRepository;
+import jaringobi.exception.auth.NoPermissionException;
 import jaringobi.exception.category.CategoryNotFoundException;
+import jaringobi.exception.expense.ExpenseNotFoundException;
 import jaringobi.exception.user.UserNotFoundException;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -45,9 +51,16 @@ public class ExpenseServiceTest {
             .name("식품")
             .build();
 
+    private final Category modifyCategory = Category.builder()
+            .id(100L)
+            .name("생필품")
+            .build();
+
     private final AppUser appUser = new AppUser(1L);
+    private final AppUser anotherUser = new AppUser(2L);
 
     private final User user = User.builder()
+            .id(1L)
             .username("username")
             .password("password")
             .build();
@@ -57,6 +70,7 @@ public class ExpenseServiceTest {
             .expenseMount(10000)
             .memo("memo")
             .expenseDateTime(LocalDateTime.now())
+            .excludeTotalExpense(false)
             .build();
 
     private final Expense mockExpense = Expense.builder()
@@ -68,6 +82,14 @@ public class ExpenseServiceTest {
             .id(1L)
             .build();
 
+    private final ModifyExpenseRequest modifyExpenseRequest = ModifyExpenseRequest.builder()
+            .excludeTotalExpense(true)
+            .expenseDateTime(LocalDateTime.of(2025, 12, 25, 0, 0))
+            .categoryId(100L)
+            .expenseMount(100_000)
+            .memo("memo2")
+            .build();
+
     @Test
     @DisplayName("지출 추가하기 성공")
     void addExpense() throws NoSuchFieldException, IllegalAccessException {
@@ -77,7 +99,10 @@ public class ExpenseServiceTest {
         when(expenseRepository.save(any())).thenReturn(mockExpense);
 
         // When
-        expenseService.addExpense(addExpenseRequest, appUser);
+        AddExpenseNoResponse addExpenseNoResponse = expenseService.addExpense(addExpenseRequest, appUser);
+
+        // Then
+        Assertions.assertThat(addExpenseNoResponse.expenseNo()).isEqualTo(1L);
 
         // Verity
         verify(expenseRepository, times(1)).save(any());
@@ -89,7 +114,7 @@ public class ExpenseServiceTest {
         // Given
         when(userRepository.findById(1L)).thenReturn(Optional.empty());
 
-        // Then
+        // When, Then
         assertThatThrownBy(() -> expenseService.addExpense(addExpenseRequest, appUser))
                 .isInstanceOf(UserNotFoundException.class);
 
@@ -105,12 +130,75 @@ public class ExpenseServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         when(categoryRepository.findById(1L)).thenReturn(Optional.empty());
 
-        // Then
+        // When, Then
         assertThatThrownBy(() -> expenseService.addExpense(addExpenseRequest, appUser))
                 .isInstanceOf(CategoryNotFoundException.class);
 
         // Verify
         verify(userRepository, times(1)).findById(any());
         verify(expenseRepository, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("지출 수정하기 성공")
+    void modifyExpense() {
+        // Given
+        when(expenseRepository.findById(1L)).thenReturn(Optional.of(mockExpense));
+        when(categoryRepository.findById(100L)).thenReturn(Optional.of(modifyCategory));
+
+        // When
+        expenseService.modifyExpense(modifyExpenseRequest, 1L, appUser);
+
+        // Then
+        assertThat(mockExpense.getMemo()).isEqualTo(modifyExpenseRequest.getMemo());
+        assertThat(mockExpense.getCategory().getId()).isEqualTo(modifyExpenseRequest.getCategoryId());
+        assertThat(mockExpense.getMoney().getAmount()).isEqualTo(modifyExpenseRequest.getExpenseMount());
+        assertThat(mockExpense.getExpenseAt()).isEqualTo(modifyExpenseRequest.getExpenseDateTime());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 카테고리의 경우 지출 수정하기 실패")
+    void throwExceptionNullCategoryWhenModifyExpense() {
+        // Given
+        when(expenseRepository.findById(1L)).thenReturn(Optional.of(mockExpense));
+        when(categoryRepository.findById(100L)).thenReturn(Optional.empty());
+
+        // When, Then
+        assertThatThrownBy(() -> expenseService.modifyExpense(modifyExpenseRequest, 1L, appUser))
+                .isInstanceOf(CategoryNotFoundException.class);
+
+        // Verify
+        verify(expenseRepository, times(1)).findById(any());
+        verify(categoryRepository, times(1)).findById(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 지출의 경우 지출 수정하기 실패")
+    void throwExceptionNullExpenseWhenModifyExpense() {
+        // Given
+        when(expenseRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // When, Then
+        assertThatThrownBy(() -> expenseService.modifyExpense(modifyExpenseRequest, 1L, appUser))
+                .isInstanceOf(ExpenseNotFoundException.class);
+
+        // Verify
+        verify(expenseRepository, times(1)).findById(any());
+        verify(categoryRepository, times(0)).findById(any());
+    }
+
+    @Test
+    @DisplayName("다른 유저가 수정하는 경우 지출 수정하기 실패")
+    void throwExceptionNullPermissionWhenModifyExpense() {
+        // Given
+        when(expenseRepository.findById(1L)).thenReturn(Optional.of(mockExpense));
+
+        // When, Then
+        assertThatThrownBy(() -> expenseService.modifyExpense(modifyExpenseRequest, 1L, anotherUser))
+                .isInstanceOf(NoPermissionException.class);
+
+        // Verify
+        verify(expenseRepository, times(1)).findById(any());
+        verify(categoryRepository, times(0)).findById(any());
     }
 }


### PR DESCRIPTION
## 🔎 PR 특이 사항

### 루트 엔티티 차제에서도 null 유무 체크 cac65f00a94983dc1f8376a9a7b5db078bc7cc4a

- 루트 엔티티 생성시 받는 인수는 외부에서 null 유무를 체크한다 하더라고 내부에서도 null 에 대한 처리를 해야한다고 생각.
`@DynamicUpdate` 와 같은 애노테이션은 null 이 아닌 필드 만을 대상으로 update 쿼리를 만들어주는 것이지, 루트 엔티티 자체와는 아무런 관련이 없음. 
- 루트 엔티티는 특정 Repository 의 기술에 종족되지 않고도 null 에 대한 안전성을 보장할 수 있어야 한다고 생각한다.