### PR TITLE
✨ Feature: 오늘 지출 안내

### DIFF
--- a/src/main/java/jaringobi/controller/query/expense/ExpenseQueryController.java
+++ b/src/main/java/jaringobi/controller/query/expense/ExpenseQueryController.java
@@ -1,0 +1,26 @@
+package jaringobi.controller.query.expense;
+
+import jaringobi.auth.AuthenticationPrincipal;
+import jaringobi.common.response.ApiResponse;
+import jaringobi.controller.query.expense.response.TodayExpenseResponse;
+import jaringobi.domain.user.AppUser;
+import jaringobi.service.search.ExpenseSearchService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/expenditures")
+public class ExpenseQueryController {
+
+    private final ExpenseSearchService expenseSearchService;
+
+    public ExpenseQueryController(ExpenseSearchService expenseSearchService) {
+        this.expenseSearchService = expenseSearchService;
+    }
+
+    @GetMapping("/today")
+    public ApiResponse<TodayExpenseResponse> query(@AuthenticationPrincipal AppUser appUser) {
+        return ApiResponse.ok(expenseSearchService.searchTodayExpense(appUser));
+    }
+}

--- a/src/main/java/jaringobi/controller/query/expense/response/TodayExpensePerCategory.java
+++ b/src/main/java/jaringobi/controller/query/expense/response/TodayExpensePerCategory.java
@@ -1,0 +1,63 @@
+package jaringobi.controller.query.expense.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import jaringobi.domain.budget.CategoryBudget;
+import java.util.List;
+import java.util.Optional;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@JsonInclude(Include.NON_NULL)
+public class TodayExpensePerCategory {
+    private long categoryId;
+    private int paidAmount;
+    private Integer availableAmount;
+    private Integer dangerPercent;
+    private boolean hasCategoryBudget;
+
+    @Builder
+    public TodayExpensePerCategory(long categoryId, int paidAmount, Integer availableAmount, Integer dangerPercent, boolean hasCategoryBudget) {
+        this.categoryId = categoryId;
+        this.paidAmount = paidAmount;
+        this.availableAmount = availableAmount;
+        this.dangerPercent = dangerPercent;
+        this.hasCategoryBudget = hasCategoryBudget;
+    }
+
+    public static TodayExpensePerCategory from(
+            TodayExpensePerCategory todayExpensePerCategory,
+            List<CategoryBudget> categoryBudget
+    ) {
+        Optional<CategoryBudget> optionalCategoryBudget = categoryBudget.stream()
+                .filter(it -> it.getCategoryId().equals(todayExpensePerCategory.categoryId))
+                .findFirst();
+        if (optionalCategoryBudget.isEmpty()) {
+            return todayExpensePerCategory;
+        }
+        int dailyCategoryBudget = optionalCategoryBudget.get().getAmount().getAmount() / 30;
+        return TodayExpensePerCategory.builder()
+                .categoryId(todayExpensePerCategory.categoryId)
+                .paidAmount(todayExpensePerCategory.paidAmount)
+                .availableAmount(optionalCategoryBudget.get().getAmount().getAmount())
+                .dangerPercent((todayExpensePerCategory.paidAmount / dailyCategoryBudget) * 100)
+                .hasCategoryBudget(true)
+                .build();
+    }
+
+    public TodayExpensePerCategory toWithBudgetSum(List<CategoryBudget> budgetsPerCategory) {
+        CategoryBudget categoryBudget = budgetsPerCategory.stream()
+                .filter(it -> it.getCategoryId() == categoryId)
+                .findFirst()
+                .orElse(null);
+        if (categoryBudget == null) {
+            return this;
+        }
+        return TodayExpensePerCategory.from(this, budgetsPerCategory);
+    }
+}

--- a/src/main/java/jaringobi/controller/query/expense/response/TodayExpenseResponse.java
+++ b/src/main/java/jaringobi/controller/query/expense/response/TodayExpenseResponse.java
@@ -1,0 +1,53 @@
+package jaringobi.controller.query.expense.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import jaringobi.domain.budget.CategoryBudget;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(Include.NON_NULL)
+public class TodayExpenseResponse {
+
+    private final List<TodayExpensePerCategory> expensesPerCategory;
+    private final long totalExpenseAmount;
+    private final boolean hasBudget;
+    private Long budgetAmount;
+    private Integer dangerPercent;
+
+    @Builder
+    public TodayExpenseResponse(List<TodayExpensePerCategory> expensesPerCategory, long totalExpenseAmount,
+            boolean hasBudget, long budgetAmount, Integer dangerPercent) {
+        this.expensesPerCategory = expensesPerCategory;
+        this.totalExpenseAmount = totalExpenseAmount;
+        this.hasBudget = hasBudget;
+        this.budgetAmount = budgetAmount;
+        this.dangerPercent = dangerPercent;
+    }
+
+    public static TodayExpenseResponse from(List<TodayExpensePerCategory> todayExpensePerCategories,
+            List<CategoryBudget> budgetsPerCategory) {
+
+        int dailyBudget = budgetsPerCategory.stream()
+                .mapToInt(it -> it.getAmount().getAmount())
+                .sum() / 30;
+
+        int dangerPercent = (todayExpensePerCategories.stream()
+                .mapToInt(TodayExpensePerCategory::getPaidAmount)
+                .sum() / dailyBudget) * 100;
+
+        return TodayExpenseResponse.builder()
+                .expensesPerCategory(todayExpensePerCategories)
+                .totalExpenseAmount(todayExpensePerCategories.stream()
+                        .mapToInt(TodayExpensePerCategory::getPaidAmount)
+                        .sum())
+                .budgetAmount(budgetsPerCategory.stream()
+                        .mapToInt(it -> it.getAmount().getAmount())
+                        .sum())
+                .hasBudget(true)
+                .dangerPercent(dangerPercent)
+                .build();
+    }
+}

--- a/src/main/java/jaringobi/domain/expense/ExpenseQueryRepository.java
+++ b/src/main/java/jaringobi/domain/expense/ExpenseQueryRepository.java
@@ -1,10 +1,15 @@
 package jaringobi.domain.expense;
 
+import jaringobi.controller.query.expense.response.TodayExpensePerCategory;
+import jaringobi.domain.budget.CategoryBudget;
 import jaringobi.domain.user.AppUser;
 import jaringobi.dto.request.ExpenseSearchCondition;
+import java.util.List;
 import org.springframework.data.domain.Page;
 
 public interface ExpenseQueryRepository {
 
     Page<Expense> searchByCondition(AppUser appUser, ExpenseSearchCondition expenseSearchCondition);
+    List<TodayExpensePerCategory> todayTotalExpense(AppUser appUser);
+    List<CategoryBudget> getBudgetsPerCategory(AppUser appUser);
 }

--- a/src/main/java/jaringobi/service/search/ExpenseSearchService.java
+++ b/src/main/java/jaringobi/service/search/ExpenseSearchService.java
@@ -30,20 +30,6 @@ public class ExpenseSearchService {
         return ExpenseSearchResponse.from(expenses, categoriesSum, expenseWithPage.isLast());
     }
 
-    /**
-     * 1. 카테고리 별로 오늘 지출한 총액을 조회함
-     *
-     * 2. 월 별 예산에 포함된 카테고리 별 예산 설정 금액들을 조회함
-     *
-     * 2.1 만약 월 별 예산이 없을 경우 1번에서 조회함 오늘 지출한 총액을 반환함
-     *
-     * 2.2 월 별 예산은 있지만 오늘 지출한 총액에 포함될 수 있는 카테고리 예산 항목이 설정되어 있지 않은 경우1번에서 조회한 오늘 지출한 총액을 반환함
-     *
-     * 3. 1번과 2번에서 조회한 결과를 바탕으로,
-     * 오늘 지출한 총액에 카테고리별 설정한 예산을 바탕으로 위험도를 계산하여 응답값에 위험도와 현재 해당 지출 카테고리에 설정된 카테고리 예산 금액을 추가하여 응답함.
-     * @param appUser
-     * @return
-     */
     @Transactional(readOnly = true)
     public TodayExpenseResponse searchTodayExpense(AppUser appUser) {
         List<TodayExpensePerCategory> todayExpensePerCategories = expenseQueryRepository.todayTotalExpense(appUser);

--- a/src/main/java/jaringobi/service/search/ExpenseSearchService.java
+++ b/src/main/java/jaringobi/service/search/ExpenseSearchService.java
@@ -1,15 +1,20 @@
 package jaringobi.service.search;
 
+import jaringobi.controller.query.expense.response.TodayExpensePerCategory;
+import jaringobi.controller.query.expense.response.TodayExpenseResponse;
 import jaringobi.controller.search.CategoryExpenseSum;
 import jaringobi.controller.search.ExpenseSearchResponse;
+import jaringobi.domain.budget.CategoryBudget;
 import jaringobi.domain.expense.Expense;
 import jaringobi.domain.expense.ExpenseQueryRepositoryImpl;
 import jaringobi.domain.user.AppUser;
 import jaringobi.dto.request.ExpenseSearchCondition;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,10 +22,45 @@ public class ExpenseSearchService {
 
     private final ExpenseQueryRepositoryImpl expenseQueryRepository;
 
+    @Transactional(readOnly = true)
     public ExpenseSearchResponse searchExpense(AppUser appUser, ExpenseSearchCondition condition) {
         Page<Expense> expenseWithPage = expenseQueryRepository.searchByCondition(appUser, condition);
         List<Expense> expenses = expenseWithPage.toList();
         List<CategoryExpenseSum> categoriesSum = expenseQueryRepository.totalSumOfCategoriesExpense(appUser, condition);
         return ExpenseSearchResponse.from(expenses, categoriesSum, expenseWithPage.isLast());
+    }
+
+    /**
+     * 1. 카테고리 별로 오늘 지출한 총액을 조회함
+     *
+     * 2. 월 별 예산에 포함된 카테고리 별 예산 설정 금액들을 조회함
+     *
+     * 2.1 만약 월 별 예산이 없을 경우 1번에서 조회함 오늘 지출한 총액을 반환함
+     *
+     * 2.2 월 별 예산은 있지만 오늘 지출한 총액에 포함될 수 있는 카테고리 예산 항목이 설정되어 있지 않은 경우1번에서 조회한 오늘 지출한 총액을 반환함
+     *
+     * 3. 1번과 2번에서 조회한 결과를 바탕으로,
+     * 오늘 지출한 총액에 카테고리별 설정한 예산을 바탕으로 위험도를 계산하여 응답값에 위험도와 현재 해당 지출 카테고리에 설정된 카테고리 예산 금액을 추가하여 응답함.
+     * @param appUser
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public TodayExpenseResponse searchTodayExpense(AppUser appUser) {
+        List<TodayExpensePerCategory> todayExpensePerCategories = expenseQueryRepository.todayTotalExpense(appUser);
+        List<CategoryBudget> budgetsPerCategory = expenseQueryRepository.getBudgetsPerCategory(appUser);
+
+        if (budgetsPerCategory.isEmpty()) {
+            return TodayExpenseResponse.builder()
+                    .expensesPerCategory(todayExpensePerCategories)
+                    .totalExpenseAmount(todayExpensePerCategories.stream()
+                            .mapToInt(TodayExpensePerCategory::getPaidAmount)
+                            .sum())
+                    .hasBudget(false)
+                    .build();
+        }
+
+        return TodayExpenseResponse.from(todayExpensePerCategories.stream()
+                .map(it -> it.toWithBudgetSum(budgetsPerCategory))
+                .collect(Collectors.toList()), budgetsPerCategory);
     }
 }

--- a/src/test/java/jaringobi/acceptance/APITest.java
+++ b/src/test/java/jaringobi/acceptance/APITest.java
@@ -8,6 +8,7 @@ import jaringobi.domain.user.User;
 import jaringobi.domain.user.UserRepository;
 import jaringobi.jwt.TokenProvider;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,7 +53,7 @@ public class APITest {
     }
 
     private void saveUsersByIds(Long... ids) {
-        List<User> users = stream(ids).map(this::createUser).toList();
+        List<User> users = stream(ids).map(this::createUser).collect(Collectors.toList());
         userRepository.saveAll(users);
     }
 

--- a/src/test/java/jaringobi/acceptance/expense/ExpenseAPI.java
+++ b/src/test/java/jaringobi/acceptance/expense/ExpenseAPI.java
@@ -44,4 +44,15 @@ public class ExpenseAPI {
                 .then()
                 .log().all().extract();
     }
+
+    public static ExtractableResponse<Response> 오늘지출안내조회(String token) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .header(AUTHORIZATION, BEARER + token)
+                .get("/api/v1/expenditures/today")
+                .andReturn()
+                .then()
+                .log().all().extract();
+    }
 }

--- a/src/test/java/jaringobi/acceptance/expense/query/ExpenseTodayAPITest.java
+++ b/src/test/java/jaringobi/acceptance/expense/query/ExpenseTodayAPITest.java
@@ -1,0 +1,276 @@
+package jaringobi.acceptance.expense.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import io.restassured.path.json.JsonPath;
+import jaringobi.acceptance.APITest;
+import jaringobi.acceptance.budget.BudgetAPI;
+import jaringobi.acceptance.expense.ExpenseAPI;
+import jaringobi.controller.query.expense.response.TodayExpensePerCategory;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("오늘 지출 안내 API")
+public class ExpenseTodayAPITest extends APITest {
+
+    @Test
+    @DisplayName("예산 설정 없이 지출 만 있는 경우")
+    void ex1() {
+        // Given
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+        String formattedDateTime = LocalDateTime.now().format(formatter);
+        String body = String.format(
+                """
+                {
+                    "memo": "친구들이랑 점심 짬뽕",
+                    "expenseMount": 10000,
+                    "categoryId": 1,
+                    "expenseDateTime": "%s"
+                }
+                """, formattedDateTime);
+
+        ExpenseAPI.지출추가요청(body, accessToken);
+
+        // When
+        var response = ExpenseAPI.오늘지출안내조회(accessToken);
+        JsonPath jsonPath = response.jsonPath();
+
+        List<TodayExpensePerCategory> todayExpensePerCategories = jsonPath.getList("data.expensesPerCategory",
+                TodayExpensePerCategory.class);
+
+        // Then
+        assertThat(response.response().statusCode()).isEqualTo(200);
+        assertThat(jsonPath.getString("data.totalExpenseAmount")).isEqualTo("10000");
+        assertThat(jsonPath.getBoolean("data.hasBudget")).isEqualTo(false);
+        assertThat(jsonPath.getInt("data.budgetAmount")).isEqualTo(0);
+
+        assertAll(
+                () -> assertThat(todayExpensePerCategories).hasSize(1),
+                () -> assertThat(todayExpensePerCategories).extracting("categoryId").containsExactly(1L),
+                () -> assertThat(todayExpensePerCategories).extracting("paidAmount").containsExactly(10000),
+                () -> assertThat(todayExpensePerCategories).extracting("hasCategoryBudget").containsExactly(false)
+        );
+    }
+
+    @Test
+    @DisplayName("예산 설정, 예산 카테고리는 있지만 지출이 하나도 없는 경우")
+    void ex2() {
+        // When
+        var response = ExpenseAPI.오늘지출안내조회(accessToken);
+        JsonPath jsonPath = response.jsonPath();
+
+        List<TodayExpensePerCategory> todayExpensePerCategories = jsonPath.getList("data.expensesPerCategory",
+                TodayExpensePerCategory.class);
+
+        // Then
+        assertThat(response.response().statusCode()).isEqualTo(200);
+        assertThat(jsonPath.getInt("data.totalExpenseAmount")).isEqualTo(0);
+        assertThat(jsonPath.getBoolean("data.hasBudget")).isEqualTo(false);
+        assertThat(jsonPath.getInt("data.budgetAmount")).isEqualTo(0);
+
+        assertAll(
+                () -> assertThat(todayExpensePerCategories).hasSize(0)
+        );
+    }
+
+    @Test
+    @DisplayName("오늘 지출은 있지만, 예산 카테고리에 겹치치 않는 경우")
+    void ex3() {
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM");
+        String month = LocalDate.now().format(dateTimeFormatter);
+
+        // Given
+        // 한 달 식비(카테고리 3) 30만원 예산 설정
+        String body = String.format(
+                """
+                    {
+                        "budgetByCategories" : [
+                            {
+                                "categoryId": 3,
+                                "money": 300000
+                            }
+                        ],
+                        "month": "%s"
+                    }
+                    """, month
+        );
+
+        // When
+        BudgetAPI.예산설정(body, accessToken);
+
+
+        // Given
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+        String formattedDateTime = LocalDateTime.now().format(formatter);
+        String body2 = String.format(
+                """
+                {
+                    "memo": "병원 감기 약값",
+                    "expenseMount": 10000,
+                    "categoryId": 4,
+                    "expenseDateTime": "%s"
+                }
+                """, formattedDateTime);
+
+        ExpenseAPI.지출추가요청(body2, accessToken);
+
+        var response = ExpenseAPI.오늘지출안내조회(accessToken);
+        JsonPath jsonPath = response.jsonPath();
+
+        List<TodayExpensePerCategory> todayExpensePerCategories = jsonPath.getList("data.expensesPerCategory",
+                TodayExpensePerCategory.class);
+
+        assertThat(response.response().statusCode()).isEqualTo(200);
+        assertThat(jsonPath.getString("data.totalExpenseAmount")).isEqualTo("10000");
+        assertThat(jsonPath.getBoolean("data.hasBudget")).isEqualTo(true);
+        assertThat(jsonPath.getInt("data.budgetAmount")).isEqualTo(300000);
+
+        assertAll(
+                () -> assertThat(todayExpensePerCategories).hasSize(1),
+                () -> assertThat(todayExpensePerCategories).extracting("categoryId").containsExactly(4L),
+                () -> assertThat(todayExpensePerCategories).extracting("paidAmount").containsExactly(10000),
+                () -> assertThat(todayExpensePerCategories).extracting("hasCategoryBudget").containsExactly(false)
+        );
+    }
+
+    @Test
+    @DisplayName("예산 설정, 예산 카테고리는 있으며, 지출도 겺치는 경우")
+    void ex4() {
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM");
+        String month = LocalDate.now().format(dateTimeFormatter);
+
+        // Given
+        // 한 달 식비(카테고리 3) 30만원 예산 설정
+        String body = String.format(
+                """
+                    {
+                        "budgetByCategories" : [
+                            {
+                                "categoryId": 3,
+                                "money": 300000
+                            }
+                        ],
+                        "month": "%s"
+                    }
+                    """, month
+        );
+
+        // When
+        BudgetAPI.예산설정(body, accessToken);
+
+        // Given
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+        String formattedDateTime = LocalDateTime.now().format(formatter);
+        String body2 = String.format(
+                """
+                {
+                    "memo": "중식 점심 짬뽕",
+                    "expenseMount": 10000,
+                    "categoryId": 3,
+                    "expenseDateTime": "%s"
+                }
+                """, formattedDateTime);
+
+        ExpenseAPI.지출추가요청(body2, accessToken);
+
+
+        var response = ExpenseAPI.오늘지출안내조회(accessToken);
+        JsonPath jsonPath = response.jsonPath();
+
+        assertThat(response.response().statusCode()).isEqualTo(200);
+        assertThat(jsonPath.getString("data.totalExpenseAmount")).isEqualTo("10000");
+        assertThat(jsonPath.getBoolean("data.hasBudget")).isEqualTo(true);
+        assertThat(jsonPath.getInt("data.budgetAmount")).isEqualTo(300000);
+        assertThat(jsonPath.getInt("data.dangerPercent")).isEqualTo(100);
+
+        List<TodayExpensePerCategory> todayExpensePerCategories = jsonPath.getList("data.expensesPerCategory",
+                TodayExpensePerCategory.class);
+
+        assertAll(
+                () -> assertThat(todayExpensePerCategories).hasSize(1),
+                () -> assertThat(todayExpensePerCategories).extracting("categoryId").containsExactly(3L),
+                () -> assertThat(todayExpensePerCategories).extracting("paidAmount").containsExactly(10000),
+                () -> assertThat(todayExpensePerCategories).extracting("availableAmount").containsExactly(300000),
+                () -> assertThat(todayExpensePerCategories).extracting("dangerPercent").containsExactly(100),
+                () -> assertThat(todayExpensePerCategories).extracting("hasCategoryBudget").containsExactly(true)
+        );
+    }
+
+    @Test
+    @DisplayName("예산 설정, 예산 카테고리는 있으며, 일부는 겹치고 일부는 겹치지 않는 경우")
+    void ex5() {
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM");
+        String month = LocalDate.now().format(dateTimeFormatter);
+
+        // Given
+        // 한 달 식비(카테고리 3) 30만원 예산 설정
+        String body = String.format(
+                """
+                    {
+                        "budgetByCategories" : [
+                            {
+                                "categoryId": 3,
+                                "money": 300000
+                            }
+                        ],
+                        "month": "%s"
+                    }
+                    """, month
+        );
+
+        // When
+        BudgetAPI.예산설정(body, accessToken);
+
+        // Given
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+        String formattedDateTime = LocalDateTime.now().format(formatter);
+
+        ExpenseAPI.지출추가요청(String.format(
+                """
+                {
+                    "memo": "중식 점심 짬뽕",
+                    "expenseMount": 10000,
+                    "categoryId": 3,
+                    "expenseDateTime": "%s"
+                }
+                """, formattedDateTime), accessToken);
+
+        ExpenseAPI.지출추가요청(String.format(
+                """
+                {
+                    "memo": "병원비 약 값",
+                    "expenseMount": 50000,
+                    "categoryId": 4,
+                    "expenseDateTime": "%s"
+                }
+                """, formattedDateTime), accessToken);
+
+
+
+        var response = ExpenseAPI.오늘지출안내조회(accessToken);
+        JsonPath jsonPath = response.jsonPath();
+
+        assertThat(response.response().statusCode()).isEqualTo(200);
+        assertThat(jsonPath.getInt("data.totalExpenseAmount")).isEqualTo(60000);
+        assertThat(jsonPath.getBoolean("data.hasBudget")).isEqualTo(true);
+        assertThat(jsonPath.getInt("data.budgetAmount")).isEqualTo(300000);
+        assertThat(jsonPath.getInt("data.dangerPercent")).isEqualTo((60000 / (300000 / 30)) * 100);
+
+        List<TodayExpensePerCategory> todayExpensePerCategories = jsonPath.getList("data.expensesPerCategory",
+                TodayExpensePerCategory.class);
+
+        assertAll(
+                () -> assertThat(todayExpensePerCategories).hasSize(2),
+                () -> assertThat(todayExpensePerCategories).extracting("categoryId").containsExactly(3L, 4L),
+                () -> assertThat(todayExpensePerCategories).extracting("paidAmount").containsExactly(10000, 50000),
+                () -> assertThat(todayExpensePerCategories).extracting("availableAmount").containsExactly(300000, null),
+                () -> assertThat(todayExpensePerCategories).extracting("dangerPercent").containsExactly(100, null),
+                () -> assertThat(todayExpensePerCategories).extracting("hasCategoryBudget").containsExactly(true, false)
+        );
+    }
+}


### PR DESCRIPTION
## 💻 작업 내역
### ✓ 오늘 지출 안내 912186853c7c9cff3efc1b7f4f3e5d63c19da9b1

**로직**
1. 카테고리 별로 오늘 지출한 총액을 조회함
2. 월 별 예산에 포함된 카테고리 별 예산 설정 금액들을 조회함
2.1 만약 월 별 예산이 없을 경우 1번에서 조회함 오늘 지출한 총액을 반환함)
2.2 월 별 예산은 있지만 오늘 지출한 총액에 포함될 수 있는 카테고리 예산 항목이 설정되어 있지 않은 경우 1번에서 조회한 오늘 지출한 총액을 반환함
3. 1번과 2번에서 조회한 결과를 바탕으로, 오늘 지출한 총액에 카테고리별 설정한 예산을 바탕으로 위험도를 계산하여 응답값에 위험도와 현재 해당 지출 카테고리에 설정된 카테고리 예산 금액을 추가하여 응답함.
